### PR TITLE
Fixing numpy update related errors

### DIFF
--- a/dense_basis/gp_sfh.py
+++ b/dense_basis/gp_sfh.py
@@ -170,13 +170,13 @@ def tuple_to_sfh(sfh_tuple, zval, interpolator = 'gp_george', decouple_sfr = Fal
     sfr_decouple_time_index = np.argmin(np.abs(time_arr_interp*cosmo.age(zval).value - decouple_sfr_time/1e3))
     if sfr_decouple_time_index == 0:
         sfr_decouple_time_index = 2
-    mass_lastbins = np.trapz(x=time_arr_interp[-sfr_decouple_time_index:]*1e9*(cosmo.age(zval).value), y=sfh[-sfr_decouple_time_index:])
+    mass_lastbins = np.trapezoid(x=time_arr_interp[-sfr_decouple_time_index:]*1e9*(cosmo.age(zval).value), y=sfh[-sfr_decouple_time_index:])
     mass_remaining = 10**(sfh_tuple[0]) - mass_lastbins
     if mass_remaining < 0:
         mass_remaining = 0
         if print_warnings == True:
             print('input SFR, M* combination is not physically consistent (log M*: %.2f, log SFR: %.2f.)' %(sfh_tuple[0],sfh_tuple[1]))
-    mass_initbins = np.trapz(x=time_arr_interp[0:(1000-sfr_decouple_time_index)]*1e9*(cosmo.age(zval).value), y=sfh[0:(1000-sfr_decouple_time_index)])
+    mass_initbins = np.trapezoid(x=time_arr_interp[0:(1000-sfr_decouple_time_index)]*1e9*(cosmo.age(zval).value), y=sfh[0:(1000-sfr_decouple_time_index)])
     sfh[0:(1000-sfr_decouple_time_index)] = sfh[0:(1000-sfr_decouple_time_index)] * mass_remaining / mass_initbins
 
     if (np.abs(np.log10(sfh[-1]) - sfh_tuple[1]) > sfr_tolerance) or (decouple_sfr == True):
@@ -215,7 +215,7 @@ def calctimes(timeax,sfh,nparams):
         #print(1*(i+1)/(nparams+1))
 
     #mass = np.log10(np.sum(sfh)*1e9)
-    mass = np.log10(np.trapz(sfh,timeax*1e9))
+    mass = np.log10(np.trapezoid(sfh,timeax*1e9))
     sfr = np.log10(sfh[-1])
 
     return mass, sfr, tx/np.amax(timeax)

--- a/dense_basis/priors.py
+++ b/dense_basis/priors.py
@@ -91,22 +91,24 @@ class Priors(object):
     def sample_mass_prior(self, size = 1):
         massval = np.random.uniform(size=size)*(self.mass_max-self.mass_min) + self.mass_min
         self.massval = massval
-        return massval
+        # Return scalar if size=1 for NumPy 2.x compatibility
+        return massval.item() if size == 1 else massval
     
     def sample_sfr_prior(self, zval = 1.0, size=1):
         if self.sfr_prior_type == 'SFRflat':
-            return np.random.uniform(size=size)*(self.sfr_max-self.sfr_min) + self.sfr_min
+            result = np.random.uniform(size=size)*(self.sfr_max-self.sfr_min) + self.sfr_min
         elif self.sfr_prior_type == 'sSFRflat':
-            return np.random.uniform(size=size)*(self.ssfr_max-self.ssfr_min) + self.ssfr_min + self.massval
+            result = np.random.uniform(size=size)*(self.ssfr_max-self.ssfr_min) + self.ssfr_min + self.massval
         elif self.sfr_prior_type == 'sSFRlognormal':
             temp = np.random.lognormal(mean = self.ssfr_mean, sigma = self.ssfr_sigma, size=size) # about a ~2.5 dex width.
             temp = temp - np.exp(self.ssfr_mean) # centered at 0
             temp = np.log10(10.0/(cosmo.age(zval).value*1e9))-temp + self.ssfr_shift # and then at the sSFR at that redshift
-            sfrval = temp + self.massval
-            return sfrval
+            result = temp + self.massval
         else:
             print('unknown SFR prior type. choose from SFRflat, sSFRflat, or sSFRlognormal.')
             return np.nan
+        # Return scalar if size=1 for NumPy 2.x compatibility
+        return result.item() if size == 1 else result
 
     def sample_tx_prior(self, size=1):
         if self.sfh_treatment == 'TNGlike':
@@ -127,23 +129,28 @@ class Priors(object):
     def sample_z_prior(self, size=1):
         zval = np.random.uniform(size=size)*(self.z_max-self.z_min) + self.z_min
         self.zval = zval
-        return zval
+        # Return scalar if size=1 for NumPy 2.x compatibility
+        return zval.item() if size == 1 else zval
 
     def sample_Z_prior(self, size=1):
         if self.met_treatment == 'flat':
-            return np.random.uniform(size=size)*(self.Z_max-self.Z_min) + self.Z_min
+            result = np.random.uniform(size=size)*(self.Z_max-self.Z_min) + self.Z_min
         elif self.met_treatment == 'massmet':
-            met = np.random.normal(scale = self.massmet_width, size=size) + (self.massval - 7)/(10.8-7) - 1.0 # roughly solar met at MW-mass
-            return met
+            result = np.random.normal(scale = self.massmet_width, size=size) + (self.massval - 7)/(10.8-7) - 1.0 # roughly solar met at MW-mass
+        # Return scalar if size=1 for NumPy 2.x compatibility
+        return result.item() if size == 1 else result
 
     def sample_Av_prior(self, size=1):
         if self.dust_model == 'Calzetti':
             if self.dust_prior == 'flat':
-                return np.random.uniform(size=size)*(self.Av_max-self.Av_min) + self.Av_min
+                result = np.random.uniform(size=size)*(self.Av_max-self.Av_min) + self.Av_min
             elif self.dust_prior == 'exp':
-                return np.random.exponential(size=size)*(self.Av_exp_scale)
+                result = np.random.exponential(size=size)*(self.Av_exp_scale)
             else:
                 print('unknown dust_prior. options are flat and exp')
+                return np.nan
+            # Return scalar if size=1 for NumPy 2.x compatibility
+            return result.item() if size == 1 else result
         if self.dust_model == 'CF00':
             # using parameters from Pacifici+16 for now
             slope_ism = np.random.uniform(size=size)*(0.6) - 1.0 # ism slope in range [-1.0,-0.4]

--- a/dense_basis/priors.py
+++ b/dense_basis/priors.py
@@ -232,7 +232,7 @@ class Priors(object):
             sfh_tuples[1,i] = ssfr + ref_mstar
             sfhs[0:,i], time = tuple_to_sfh(sfh_tuples[0:,i], zval = zval)
             sfr_error[i] = np.log10(sfhs[-1,i]) - sfh_tuples[1,i]
-            mass_error[i] = np.log10(np.trapz(x=time*1e9, y=sfhs[0:,i])) - sfh_tuples[0,i]
+            mass_error[i] = np.log10(np.trapezoid(x=time*1e9, y=sfhs[0:,i])) - sfh_tuples[0,i]
 
         # sfr_error[sfr_error<-2] = -2
         # sfr_error[sfr_error>2] = 2

--- a/dense_basis/sed_fitter.py
+++ b/dense_basis/sed_fitter.py
@@ -455,7 +455,7 @@ def evaluate_MAP(qty, weights, bins, smooth = 'kde', lowess_frac = 0.3, bw_metho
         MAP = xaxis[np.argmax(post)+1]
 
     if vb == True:
-        areapost = np.trapz(x=xaxis_centers, y=post)
+        areapost = np.trapezoid(x=xaxis_centers, y=post)
         plt.plot(xaxis_centers, post/areapost)
         if smooth == 'lowess':
             plt.plot(a[0:,0],a[0:,1]/areapost)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 numpy>=2.0
-nbsphinx
+scipy
+matplotlib
+astropy
+tqdm
+statsmodels
 george
 corner
-schwimmbad
 hickle
+schwimmbad
+nbsphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy>=2.0
 nbsphinx
 george
 corner

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,16 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         ],
-    install_requires=["numpy>=2.0", "george", "corner", "hickle", "schwimmbad"]
+    install_requires=[
+        "numpy>=2.0",
+        "scipy",
+        "matplotlib",
+        "astropy",
+        "tqdm",
+        "statsmodels",
+        "george",
+        "corner",
+        "hickle",
+        "schwimmbad"
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,28 @@
 from setuptools import setup
-import glob
-import os
 
 setup(
     name="dense_basis",
     version="0.1.9",
     author="Kartheik Iyer",
     author_email="kartheik.iyer@dunlap.utoronto.ca",
-    url = "https://github.com/kartheikiyer/dense_basis",
+    url="https://github.com/kartheikiyer/dense_basis",
     packages=["dense_basis"],
     description="SED fitting with non-parametric star formation histories",
     long_description=open("README.md").read(),
-    package_data={"": ["README.md", "LICENSE"], "dense_basis": ["train_data/*.mat", "train_data/alpha_lookup_tables/*.npy", "pregrids/*.mat", "filters/*.dat", "filters/filter_curves/goods_s/*.*","filters/filter_curves/goods_n/*.*", "filters/filter_curves/cosmos/*.*", "filters/filter_curves/egs/*.*", "filters/filter_curves/uds/*.*"]},
+    package_data={
+        "": ["README.md", "LICENSE"],
+        "dense_basis": [
+            "train_data/*.mat",
+            "train_data/alpha_lookup_tables/*.npy",
+            "pregrids/*.mat",
+            "filters/*.dat",
+            "filters/filter_curves/goods_s/*.*",
+            "filters/filter_curves/goods_n/*.*",
+            "filters/filter_curves/cosmos/*.*",
+            "filters/filter_curves/egs/*.*",
+            "filters/filter_curves/uds/*.*",
+        ],
+    },
     include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -20,7 +31,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
-        ],
+    ],
     install_requires=[
         "numpy>=2.0",
         "scipy",
@@ -31,6 +42,6 @@ setup(
         "george",
         "corner",
         "hickle",
-        "schwimmbad"
-    ]
+        "schwimmbad",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         ],
-    install_requires=["george", "corner", "hickle", "schwimmbad"]
+    install_requires=["numpy>=2.0", "george", "corner", "hickle", "schwimmbad"]
 )


### PR DESCRIPTION
Numpy's recent update to 2.4 (about a week ago at the time of writing) has removed `np.trapz` in favour of `np.trapezoid`. The latter was introduced in Numpy version 2.0 which is compatible with Python 3.9 onwards. 

The other big error inducing change was that size 1 array's a treated slightly differently now making `.item()` to get scalars a safer method of extraction. 

In this PR I have made the naming switch, used `.item()` where appropriate, and I have made the numpy version dependency explicit by including it in the requirments.txt and setup.py files (along with the other dependencies needed by the code). 